### PR TITLE
Do Not Merge: MonkeyPatch string_decoder patch upgrade

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -229,7 +229,7 @@ class Connection(_mysql.connection):
             return b'_binary' + db.string_literal(obj)
 
         def string_decoder(s):
-            return self.parent_string_decoder(s, db.encoding)
+            return self.decode_string_with_encoding(s, db.encoding)
 
         if not charset:
             charset = self.character_set_name()
@@ -252,7 +252,7 @@ class Connection(_mysql.connection):
                 self.autocommit(autocommit)
         self.messages = []
 
-    def parent_string_decoder(self, s, encoding):
+    def decode_string_with_encoding(self, s, encoding):
         raise NotImplementedError("Override this method.")
 
     def autocommit(self, on):

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -228,7 +228,12 @@ class Connection(_mysql.connection):
             return b'_binary' + db.string_literal(obj)
 
         def string_decoder(s):
-            return s.decode(db.encoding)
+            if PY2:
+                return s.decode(db.encoding)
+            return s.decode(
+                db.encoding,
+                errors='backslashreplace'
+            )
 
         if not charset:
             charset = self.character_set_name()

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -228,12 +228,7 @@ class Connection(_mysql.connection):
             return b'_binary' + db.string_literal(obj)
 
         def string_decoder(s):
-            if PY2:
-                return s.decode(db.encoding)
-            return s.decode(
-                db.encoding,
-                errors='ignore'
-            )
+            return self.parent_string_decoder(db, s)
 
         if not charset:
             charset = self.character_set_name()
@@ -255,6 +250,9 @@ class Connection(_mysql.connection):
             if autocommit is not None:
                 self.autocommit(autocommit)
         self.messages = []
+
+    def parent_string_decoder(self, db, s):
+        raise NotImplementedError("Override this method.")
 
     def autocommit(self, on):
         on = bool(on)

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -16,11 +16,11 @@ from _mysql_exceptions import (
 )
 import _mysql
 
-
 if not PY2:
     if sys.version_info[:2] < (3, 6):
         # See http://bugs.python.org/issue24870
         _surrogateescape_table = [chr(i) if i < 0x80 else chr(i + 0xdc00) for i in range(256)]
+
 
         def _fast_surrogateescape(s):
             return s.decode('latin1').translate(_surrogateescape_table)
@@ -55,6 +55,7 @@ def defaulterrorhandler(connection, cursor, errorclass, errorvalue):
 
 
 re_numeric_part = re.compile(r"^(\d+)")
+
 
 def numeric_part(s):
     """Returns the leading numeric part of a string.
@@ -189,7 +190,7 @@ class Connection(_mysql.connection):
         self._binary_prefix = kwargs2.pop('binary_prefix', False)
 
         client_flag = kwargs.get('client_flag', 0)
-        client_version = tuple([ numeric_part(n) for n in _mysql.get_client_info().split('.')[:2] ])
+        client_version = tuple([numeric_part(n) for n in _mysql.get_client_info().split('.')[:2]])
         if client_version >= (4, 1):
             client_flag |= CLIENT.MULTI_STATEMENTS
         if client_version >= (5, 0):
@@ -203,10 +204,10 @@ class Connection(_mysql.connection):
 
         super(Connection, self).__init__(*args, **kwargs2)
         self.cursorclass = cursorclass
-        self.encoders = dict([ (k, v) for k, v in conv.items()
-                               if type(k) is not int ])
+        self.encoders = dict([(k, v) for k, v in conv.items()
+                              if type(k) is not int])
 
-        self._server_version = tuple([ numeric_part(n) for n in self.get_server_info().split('.')[:2] ])
+        self._server_version = tuple([numeric_part(n) for n in self.get_server_info().split('.')[:2]])
 
         self.encoding = 'ascii'  # overriden in set_character_set()
         db = proxy(self)
@@ -228,7 +229,7 @@ class Connection(_mysql.connection):
             return b'_binary' + db.string_literal(obj)
 
         def string_decoder(s):
-            return self.parent_string_decoder(db, s)
+            return self.parent_string_decoder(s, db.encoding)
 
         if not charset:
             charset = self.character_set_name()
@@ -251,7 +252,7 @@ class Connection(_mysql.connection):
                 self.autocommit(autocommit)
         self.messages = []
 
-    def parent_string_decoder(self, db, s):
+    def parent_string_decoder(self, s, encoding):
         raise NotImplementedError("Override this method.")
 
     def autocommit(self, on):
@@ -380,7 +381,7 @@ class Connection(_mysql.connection):
         sequence of tuples of (Level, Code, Message). This
         is only supported in MySQL-4.1 and up. If your server
         is an earlier version, an empty sequence is returned."""
-        if self._server_version < (4,1): return ()
+        if self._server_version < (4, 1): return ()
         self.query("SHOW WARNINGS")
         r = self.store_result()
         warnings = r.fetch_row(0)

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -232,7 +232,7 @@ class Connection(_mysql.connection):
                 return s.decode(db.encoding)
             return s.decode(
                 db.encoding,
-                errors='backslashreplace'
+                errors='ignore'
             )
 
         if not charset:

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -228,6 +228,7 @@ class Connection(_mysql.connection):
         def bytes_literal(obj, dummy=None):
             return b'_binary' + db.string_literal(obj)
 
+        self._last_query = None
         def string_decoder(s):
             return self.decode_string_with_encoding(s, db.encoding)
 
@@ -274,6 +275,8 @@ class Connection(_mysql.connection):
         # Since _mysql releases GIL while querying, we need immutable buffer.
         if isinstance(query, bytearray):
             query = bytes(query)
+
+        self._last_query = query
         if self.waiter is not None:
             self.send_query(query)
             self.waiter(self.fileno())

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -16,11 +16,11 @@ from _mysql_exceptions import (
 )
 import _mysql
 
+
 if not PY2:
     if sys.version_info[:2] < (3, 6):
         # See http://bugs.python.org/issue24870
         _surrogateescape_table = [chr(i) if i < 0x80 else chr(i + 0xdc00) for i in range(256)]
-
 
         def _fast_surrogateescape(s):
             return s.decode('latin1').translate(_surrogateescape_table)
@@ -55,7 +55,6 @@ def defaulterrorhandler(connection, cursor, errorclass, errorvalue):
 
 
 re_numeric_part = re.compile(r"^(\d+)")
-
 
 def numeric_part(s):
     """Returns the leading numeric part of a string.
@@ -190,7 +189,7 @@ class Connection(_mysql.connection):
         self._binary_prefix = kwargs2.pop('binary_prefix', False)
 
         client_flag = kwargs.get('client_flag', 0)
-        client_version = tuple([numeric_part(n) for n in _mysql.get_client_info().split('.')[:2]])
+        client_version = tuple([ numeric_part(n) for n in _mysql.get_client_info().split('.')[:2] ])
         if client_version >= (4, 1):
             client_flag |= CLIENT.MULTI_STATEMENTS
         if client_version >= (5, 0):
@@ -204,10 +203,10 @@ class Connection(_mysql.connection):
 
         super(Connection, self).__init__(*args, **kwargs2)
         self.cursorclass = cursorclass
-        self.encoders = dict([(k, v) for k, v in conv.items()
-                              if type(k) is not int])
+        self.encoders = dict([ (k, v) for k, v in conv.items()
+                               if type(k) is not int ])
 
-        self._server_version = tuple([numeric_part(n) for n in self.get_server_info().split('.')[:2]])
+        self._server_version = tuple([ numeric_part(n) for n in self.get_server_info().split('.')[:2] ])
 
         self.encoding = 'ascii'  # overriden in set_character_set()
         db = proxy(self)
@@ -381,7 +380,7 @@ class Connection(_mysql.connection):
         sequence of tuples of (Level, Code, Message). This
         is only supported in MySQL-4.1 and up. If your server
         is an earlier version, an empty sequence is returned."""
-        if self._server_version < (4, 1): return ()
+        if self._server_version < (4,1): return ()
         self.query("SHOW WARNINGS")
         r = self.store_result()
         warnings = r.fetch_row(0)

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -6,6 +6,7 @@ override Connection.default_cursor with a non-standard Cursor class.
 """
 import re
 import sys
+import warnings
 
 from MySQLdb import cursors
 from MySQLdb.compat import unicode, PY2
@@ -252,7 +253,8 @@ class Connection(_mysql.connection):
         self.messages = []
 
     def decode_string_with_encoding(self, s, encoding):
-        raise NotImplementedError("Override this method.")
+        warnings.warn('mysqlclient: This method should not be getting called. Is the monkeypatch working correctly?')
+        return s.decode(encoding)
 
     def autocommit(self, on):
         on = bool(on)

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -229,8 +229,9 @@ class Connection(_mysql.connection):
             return b'_binary' + db.string_literal(obj)
 
         self._last_query = None
+
         def string_decoder(s):
-            return self.decode_string_with_encoding(s, db.encoding)
+            return self.decode_string_with_encoding(s, db.encoding, self._last_query)
 
         if not charset:
             charset = self.character_set_name()
@@ -253,7 +254,7 @@ class Connection(_mysql.connection):
                 self.autocommit(autocommit)
         self.messages = []
 
-    def decode_string_with_encoding(self, s, encoding):
+    def decode_string_with_encoding(self, s, encoding, last_query):
         warnings.warn('mysqlclient: This method should not be getting called. Is the monkeypatch working correctly?')
         return s.decode(encoding)
 

--- a/metadata.cfg
+++ b/metadata.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version: 1.3.12.k1
+version: 1.3.12.k2
 version_info: (1,3,12,'final',0)
 description: Python interface to MySQL
 long_description: 

--- a/metadata.cfg
+++ b/metadata.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version: 1.3.12
+version: 1.3.12.k
 version_info: (1,3,12,'final',0)
 description: Python interface to MySQL
 long_description: 

--- a/metadata.cfg
+++ b/metadata.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version: 1.3.12.k
+version: 1.3.12.k1
 version_info: (1,3,12,'final',0)
 description: Python interface to MySQL
 long_description: 

--- a/metadata.cfg
+++ b/metadata.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version: 1.3.12.k2
+version: 1.3.12.k
 version_info: (1,3,12,'final',0)
 description: Python interface to MySQL
 long_description: 

--- a/metadata.cfg
+++ b/metadata.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version: 1.3.12.k
+version: 1.3.12.1
 version_info: (1,3,12,'final',0)
 description: Python interface to MySQL
 long_description: 


### PR DESCRIPTION
# DO NOT MERGE

This branch uses `py3_decode_backslashreplace` as a base and merges tag `1.3.13` from upstream, to effectively upgrade the version used with our monkey patch.

This is being done as part of the Django 2.2 upgrade since the minimum version of `mysqlclient` needed is `1.3.13` 

See https://docs.djangoproject.com/en/2.2/ref/databases/#id6